### PR TITLE
addUnionTypeSupport

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 export { createSchema } from "./lib/common";
 export { createEnum } from "./lib/enum";
+export { createUnion } from "./lib/union";
 
 export { default as arg } from "./decorators/arg";
 export { default as context } from "./decorators/context";

--- a/src/lib/common.ts
+++ b/src/lib/common.ts
@@ -6,10 +6,12 @@ import {
   GraphQLSchema,
   GraphQLString,
   GraphQLList,
-  GraphQLNonNull
+  GraphQLNonNull,
+  isUnionType
 } from "graphql";
 import Metadata from "./Metadata";
 import { getEnumType } from "./enum";
+import { getUnionType } from "./union";
 
 const outputTypes: any[] = [];
 
@@ -170,6 +172,9 @@ export function getParameterName(method: Function, index: number) {
 export function getGraphQLType(typeKey, target, propertyKey) {
   if (isEnumType(typeKey)) {
     return getEnumType(typeKey, target, propertyKey);
+  }
+  if (isUnionType(typeKey)) {
+    return getUnionType(typeKey);
   }
   return (
     (isClass(typeKey) && interfaceTypeMap.get(typeKey)) || typeMap.get(typeKey)

--- a/src/lib/union.ts
+++ b/src/lib/union.ts
@@ -1,0 +1,30 @@
+import { GraphQLUnionType } from "graphql";
+import { getType } from "./common";
+
+const unionTypeMap = new Map();
+
+/**
+ * this function directly to define the union before it is used.
+ * @param {string} name
+ * @param types
+ */
+export function createUnion(name, types) {
+  const unionType = new GraphQLUnionType({
+    name,
+    types: types.map(oneType => {
+      return getType(oneType);
+    }),
+    resolveType: value => {
+      const theType = types.find(oneType => {
+        return value instanceof oneType;
+      });
+      return getType(theType);
+    }
+  });
+  unionTypeMap.set(unionType, unionType);
+  return unionType;
+}
+
+export function getUnionType(typeKey) {
+  return unionTypeMap.get(typeKey);
+}

--- a/test/lib/union.test.ts
+++ b/test/lib/union.test.ts
@@ -30,7 +30,7 @@ class UnionQuery {
     return oneDog;
   }
 }
-describe.only("Test Union types", () => {
+describe("Test Union types", () => {
   it("should be able to return an union type", async () => {
     const server = new TestServer(createSchema(UnionQuery));
     const { body } = await server.query({

--- a/test/lib/union.test.ts
+++ b/test/lib/union.test.ts
@@ -1,0 +1,41 @@
+import { expect } from "chai";
+import { type, field, createSchema, createUnion, Int } from "../../src";
+import TestServer from "../TestServer";
+
+@type
+class Dog {
+  @field(String)
+  id;
+
+  @field(String)
+  name;
+}
+
+@type
+class Cat {
+  @field(String)
+  id;
+
+  @field(Int)
+  age;
+}
+const PetType = createUnion("PetType", [Cat, Dog]);
+@type
+class UnionQuery {
+  @field(PetType)
+  get value() {
+    const oneDog = new Dog();
+    oneDog.id = "dog1";
+    oneDog.name = "dog1";
+    return oneDog;
+  }
+}
+describe.only("Test Union types", () => {
+  it("should be able to return an union type", async () => {
+    const server = new TestServer(createSchema(UnionQuery));
+    const { body } = await server.query({
+      query: `{ value {...on Dog{name}} }`
+    });
+    expect(body).to.deep.equal({ data: { value: { name: "dog1" } } });
+  });
+});


### PR DESCRIPTION
the usage like test shows

```
import { expect } from "chai";
import { type, field, createSchema, createUnion, Int } from "../../src";
import TestServer from "../TestServer";
 @type
class Dog {
  @field(String)
  id;
   @field(String)
  name;
}
 @type
class Cat {
  @field(String)
  id;
   @field(Int)
  age;
}
const PetType = createUnion("PetType", [Cat, Dog]);
@type
class UnionQuery {
  @field(PetType)
  get value() {
    const oneDog = new Dog();
    oneDog.id = "dog1";
    oneDog.name = "dog1";
    return oneDog;
  }
}
describe.only("Test Union types", () => {
  it("should be able to return an union type", async () => {
    const server = new TestServer(createSchema(UnionQuery));
    const { body } = await server.query({
      query: `{ value {...on Dog{name}} }`
    });
    expect(body).to.deep.equal({ data: { value: { name: "dog1" } } });
  });
});
```

@corycook , @zgrossbart  would have a review this ?